### PR TITLE
docs: bump esp-idf version to 5.1.2, fix installation guide anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ The button interface is the exact same as the [M5Stack Core Basic](#m5stack-core
 ## Set-Up Instructions
 
 There are three options for flashing your device:
-- [**Install with the Semi-Automated Script**](#install-with-the-semi-automated-script) (easiest way)
-- [**Install with a Device-Specific Script**](#install-with-a-device-specific-script) (another easy way)
-- [**Install by Running the Code Manually**](#install-by-running-the-code-manually) (harder way)
+- [**Install with the Semi-Automated Script**](#use-the-semi-automated-script) (easiest way)
+- [**Install with a Device-Specific Script**](#use-a-device-specific-script) (another easy way)
+- [**Install by Running the Code Manually**](#run-the-commands-manually) (harder way)
 
 ### Use the Semi-Automated Script
 
@@ -198,7 +198,7 @@ This options is provided for people who want to run the commands themselves.
     sudo apt update
     sudo apt install -y cmake git python3-pip python3-venv
     [ -d ${HOME}/esp ] || mkdir ${HOME}/esp
-    git clone -b v5.1.1 --recursive https://github.com/espressif/esp-idf.git ${HOME}/esp/esp-idf
+    git clone -b v5.1.2 --recursive https://github.com/espressif/esp-idf.git ${HOME}/esp/esp-idf
     cd "${HOME}"/esp/esp-idf
     ./install.sh esp32
     . ./export.sh


### PR DESCRIPTION
To get the documentation ready for the workshop i checked the manual installation and found that the linked esp-idf version does not match to the latest jade version. I bumped the esp-idf verison to 5.1.2 and also fixed anchored links